### PR TITLE
[codex] fix dotted node id resolution

### DIFF
--- a/.codex/skills/openspec-apply-change/SKILL.md
+++ b/.codex/skills/openspec-apply-change/SKILL.md
@@ -1,0 +1,156 @@
+---
+name: openspec-apply-change
+description: Implement tasks from an OpenSpec change. Use when the user wants to start implementing, continue implementation, or work through tasks.
+license: MIT
+compatibility: Requires openspec CLI.
+metadata:
+  author: openspec
+  version: "1.0"
+  generatedBy: "1.2.0"
+---
+
+Implement tasks from an OpenSpec change.
+
+**Input**: Optionally specify a change name. If omitted, check if it can be inferred from conversation context. If vague or ambiguous you MUST prompt for available changes.
+
+**Steps**
+
+1. **Select the change**
+
+   If a name is provided, use it. Otherwise:
+   - Infer from conversation context if the user mentioned a change
+   - Auto-select if only one active change exists
+   - If ambiguous, run `openspec list --json` to get available changes and use the **AskUserQuestion tool** to let the user select
+
+   Always announce: "Using change: <name>" and how to override (e.g., `/opsx:apply <other>`).
+
+2. **Check status to understand the schema**
+   ```bash
+   openspec status --change "<name>" --json
+   ```
+   Parse the JSON to understand:
+   - `schemaName`: The workflow being used (e.g., "spec-driven")
+   - Which artifact contains the tasks (typically "tasks" for spec-driven, check status for others)
+
+3. **Get apply instructions**
+
+   ```bash
+   openspec instructions apply --change "<name>" --json
+   ```
+
+   This returns:
+   - Context file paths (varies by schema - could be proposal/specs/design/tasks or spec/tests/implementation/docs)
+   - Progress (total, complete, remaining)
+   - Task list with status
+   - Dynamic instruction based on current state
+
+   **Handle states:**
+   - If `state: "blocked"` (missing artifacts): show message, suggest using openspec-continue-change
+   - If `state: "all_done"`: congratulate, suggest archive
+   - Otherwise: proceed to implementation
+
+4. **Read context files**
+
+   Read the files listed in `contextFiles` from the apply instructions output.
+   The files depend on the schema being used:
+   - **spec-driven**: proposal, specs, design, tasks
+   - Other schemas: follow the contextFiles from CLI output
+
+5. **Show current progress**
+
+   Display:
+   - Schema being used
+   - Progress: "N/M tasks complete"
+   - Remaining tasks overview
+   - Dynamic instruction from CLI
+
+6. **Implement tasks (loop until done or blocked)**
+
+   For each pending task:
+   - Show which task is being worked on
+   - Make the code changes required
+   - Keep changes minimal and focused
+   - Mark task complete in the tasks file: `- [ ]` → `- [x]`
+   - Continue to next task
+
+   **Pause if:**
+   - Task is unclear → ask for clarification
+   - Implementation reveals a design issue → suggest updating artifacts
+   - Error or blocker encountered → report and wait for guidance
+   - User interrupts
+
+7. **On completion or pause, show status**
+
+   Display:
+   - Tasks completed this session
+   - Overall progress: "N/M tasks complete"
+   - If all done: suggest archive
+   - If paused: explain why and wait for guidance
+
+**Output During Implementation**
+
+```
+## Implementing: <change-name> (schema: <schema-name>)
+
+Working on task 3/7: <task description>
+[...implementation happening...]
+✓ Task complete
+
+Working on task 4/7: <task description>
+[...implementation happening...]
+✓ Task complete
+```
+
+**Output On Completion**
+
+```
+## Implementation Complete
+
+**Change:** <change-name>
+**Schema:** <schema-name>
+**Progress:** 7/7 tasks complete ✓
+
+### Completed This Session
+- [x] Task 1
+- [x] Task 2
+...
+
+All tasks complete! Ready to archive this change.
+```
+
+**Output On Pause (Issue Encountered)**
+
+```
+## Implementation Paused
+
+**Change:** <change-name>
+**Schema:** <schema-name>
+**Progress:** 4/7 tasks complete
+
+### Issue Encountered
+<description of the issue>
+
+**Options:**
+1. <option 1>
+2. <option 2>
+3. Other approach
+
+What would you like to do?
+```
+
+**Guardrails**
+- Keep going through tasks until done or blocked
+- Always read context files before starting (from the apply instructions output)
+- If task is ambiguous, pause and ask before implementing
+- If implementation reveals issues, pause and suggest artifact updates
+- Keep code changes minimal and scoped to each task
+- Update task checkbox immediately after completing each task
+- Pause on errors, blockers, or unclear requirements - don't guess
+- Use contextFiles from CLI output, don't assume specific file names
+
+**Fluid Workflow Integration**
+
+This skill supports the "actions on a change" model:
+
+- **Can be invoked anytime**: Before all artifacts are done (if tasks exist), after partial implementation, interleaved with other actions
+- **Allows artifact updates**: If implementation reveals design issues, suggest updating artifacts - not phase-locked, work fluidly

--- a/.codex/skills/openspec-archive-change/SKILL.md
+++ b/.codex/skills/openspec-archive-change/SKILL.md
@@ -1,0 +1,114 @@
+---
+name: openspec-archive-change
+description: Archive a completed change in the experimental workflow. Use when the user wants to finalize and archive a change after implementation is complete.
+license: MIT
+compatibility: Requires openspec CLI.
+metadata:
+  author: openspec
+  version: "1.0"
+  generatedBy: "1.2.0"
+---
+
+Archive a completed change in the experimental workflow.
+
+**Input**: Optionally specify a change name. If omitted, check if it can be inferred from conversation context. If vague or ambiguous you MUST prompt for available changes.
+
+**Steps**
+
+1. **If no change name provided, prompt for selection**
+
+   Run `openspec list --json` to get available changes. Use the **AskUserQuestion tool** to let the user select.
+
+   Show only active changes (not already archived).
+   Include the schema used for each change if available.
+
+   **IMPORTANT**: Do NOT guess or auto-select a change. Always let the user choose.
+
+2. **Check artifact completion status**
+
+   Run `openspec status --change "<name>" --json` to check artifact completion.
+
+   Parse the JSON to understand:
+   - `schemaName`: The workflow being used
+   - `artifacts`: List of artifacts with their status (`done` or other)
+
+   **If any artifacts are not `done`:**
+   - Display warning listing incomplete artifacts
+   - Use **AskUserQuestion tool** to confirm user wants to proceed
+   - Proceed if user confirms
+
+3. **Check task completion status**
+
+   Read the tasks file (typically `tasks.md`) to check for incomplete tasks.
+
+   Count tasks marked with `- [ ]` (incomplete) vs `- [x]` (complete).
+
+   **If incomplete tasks found:**
+   - Display warning showing count of incomplete tasks
+   - Use **AskUserQuestion tool** to confirm user wants to proceed
+   - Proceed if user confirms
+
+   **If no tasks file exists:** Proceed without task-related warning.
+
+4. **Assess delta spec sync state**
+
+   Check for delta specs at `openspec/changes/<name>/specs/`. If none exist, proceed without sync prompt.
+
+   **If delta specs exist:**
+   - Compare each delta spec with its corresponding main spec at `openspec/specs/<capability>/spec.md`
+   - Determine what changes would be applied (adds, modifications, removals, renames)
+   - Show a combined summary before prompting
+
+   **Prompt options:**
+   - If changes needed: "Sync now (recommended)", "Archive without syncing"
+   - If already synced: "Archive now", "Sync anyway", "Cancel"
+
+   If user chooses sync, use Task tool (subagent_type: "general-purpose", prompt: "Use Skill tool to invoke openspec-sync-specs for change '<name>'. Delta spec analysis: <include the analyzed delta spec summary>"). Proceed to archive regardless of choice.
+
+5. **Perform the archive**
+
+   Create the archive directory if it doesn't exist:
+   ```bash
+   mkdir -p openspec/changes/archive
+   ```
+
+   Generate target name using current date: `YYYY-MM-DD-<change-name>`
+
+   **Check if target already exists:**
+   - If yes: Fail with error, suggest renaming existing archive or using different date
+   - If no: Move the change directory to archive
+
+   ```bash
+   mv openspec/changes/<name> openspec/changes/archive/YYYY-MM-DD-<name>
+   ```
+
+6. **Display summary**
+
+   Show archive completion summary including:
+   - Change name
+   - Schema that was used
+   - Archive location
+   - Whether specs were synced (if applicable)
+   - Note about any warnings (incomplete artifacts/tasks)
+
+**Output On Success**
+
+```
+## Archive Complete
+
+**Change:** <change-name>
+**Schema:** <schema-name>
+**Archived to:** openspec/changes/archive/YYYY-MM-DD-<name>/
+**Specs:** ✓ Synced to main specs (or "No delta specs" or "Sync skipped")
+
+All artifacts complete. All tasks complete.
+```
+
+**Guardrails**
+- Always prompt for change selection if not provided
+- Use artifact graph (openspec status --json) for completion checking
+- Don't block archive on warnings - just inform and confirm
+- Preserve .openspec.yaml when moving to archive (it moves with the directory)
+- Show clear summary of what happened
+- If sync is requested, use openspec-sync-specs approach (agent-driven)
+- If delta specs exist, always run the sync assessment and show the combined summary before prompting

--- a/.codex/skills/openspec-explore/SKILL.md
+++ b/.codex/skills/openspec-explore/SKILL.md
@@ -1,0 +1,288 @@
+---
+name: openspec-explore
+description: Enter explore mode - a thinking partner for exploring ideas, investigating problems, and clarifying requirements. Use when the user wants to think through something before or during a change.
+license: MIT
+compatibility: Requires openspec CLI.
+metadata:
+  author: openspec
+  version: "1.0"
+  generatedBy: "1.2.0"
+---
+
+Enter explore mode. Think deeply. Visualize freely. Follow the conversation wherever it goes.
+
+**IMPORTANT: Explore mode is for thinking, not implementing.** You may read files, search code, and investigate the codebase, but you must NEVER write code or implement features. If the user asks you to implement something, remind them to exit explore mode first and create a change proposal. You MAY create OpenSpec artifacts (proposals, designs, specs) if the user asks—that's capturing thinking, not implementing.
+
+**This is a stance, not a workflow.** There are no fixed steps, no required sequence, no mandatory outputs. You're a thinking partner helping the user explore.
+
+---
+
+## The Stance
+
+- **Curious, not prescriptive** - Ask questions that emerge naturally, don't follow a script
+- **Open threads, not interrogations** - Surface multiple interesting directions and let the user follow what resonates. Don't funnel them through a single path of questions.
+- **Visual** - Use ASCII diagrams liberally when they'd help clarify thinking
+- **Adaptive** - Follow interesting threads, pivot when new information emerges
+- **Patient** - Don't rush to conclusions, let the shape of the problem emerge
+- **Grounded** - Explore the actual codebase when relevant, don't just theorize
+
+---
+
+## What You Might Do
+
+Depending on what the user brings, you might:
+
+**Explore the problem space**
+- Ask clarifying questions that emerge from what they said
+- Challenge assumptions
+- Reframe the problem
+- Find analogies
+
+**Investigate the codebase**
+- Map existing architecture relevant to the discussion
+- Find integration points
+- Identify patterns already in use
+- Surface hidden complexity
+
+**Compare options**
+- Brainstorm multiple approaches
+- Build comparison tables
+- Sketch tradeoffs
+- Recommend a path (if asked)
+
+**Visualize**
+```
+┌─────────────────────────────────────────┐
+│     Use ASCII diagrams liberally        │
+├─────────────────────────────────────────┤
+│                                         │
+│   ┌────────┐         ┌────────┐        │
+│   │ State  │────────▶│ State  │        │
+│   │   A    │         │   B    │        │
+│   └────────┘         └────────┘        │
+│                                         │
+│   System diagrams, state machines,      │
+│   data flows, architecture sketches,    │
+│   dependency graphs, comparison tables  │
+│                                         │
+└─────────────────────────────────────────┘
+```
+
+**Surface risks and unknowns**
+- Identify what could go wrong
+- Find gaps in understanding
+- Suggest spikes or investigations
+
+---
+
+## OpenSpec Awareness
+
+You have full context of the OpenSpec system. Use it naturally, don't force it.
+
+### Check for context
+
+At the start, quickly check what exists:
+```bash
+openspec list --json
+```
+
+This tells you:
+- If there are active changes
+- Their names, schemas, and status
+- What the user might be working on
+
+### When no change exists
+
+Think freely. When insights crystallize, you might offer:
+
+- "This feels solid enough to start a change. Want me to create a proposal?"
+- Or keep exploring - no pressure to formalize
+
+### When a change exists
+
+If the user mentions a change or you detect one is relevant:
+
+1. **Read existing artifacts for context**
+   - `openspec/changes/<name>/proposal.md`
+   - `openspec/changes/<name>/design.md`
+   - `openspec/changes/<name>/tasks.md`
+   - etc.
+
+2. **Reference them naturally in conversation**
+   - "Your design mentions using Redis, but we just realized SQLite fits better..."
+   - "The proposal scopes this to premium users, but we're now thinking everyone..."
+
+3. **Offer to capture when decisions are made**
+
+   | Insight Type | Where to Capture |
+   |--------------|------------------|
+   | New requirement discovered | `specs/<capability>/spec.md` |
+   | Requirement changed | `specs/<capability>/spec.md` |
+   | Design decision made | `design.md` |
+   | Scope changed | `proposal.md` |
+   | New work identified | `tasks.md` |
+   | Assumption invalidated | Relevant artifact |
+
+   Example offers:
+   - "That's a design decision. Capture it in design.md?"
+   - "This is a new requirement. Add it to specs?"
+   - "This changes scope. Update the proposal?"
+
+4. **The user decides** - Offer and move on. Don't pressure. Don't auto-capture.
+
+---
+
+## What You Don't Have To Do
+
+- Follow a script
+- Ask the same questions every time
+- Produce a specific artifact
+- Reach a conclusion
+- Stay on topic if a tangent is valuable
+- Be brief (this is thinking time)
+
+---
+
+## Handling Different Entry Points
+
+**User brings a vague idea:**
+```
+User: I'm thinking about adding real-time collaboration
+
+You: Real-time collab is a big space. Let me think about this...
+
+      COLLABORATION SPECTRUM
+      ════════════════════════════════════════════
+
+      Awareness          Coordination         Sync
+          │                   │                 │
+          ▼                   ▼                 ▼
+      ┌────────┐         ┌────────┐        ┌────────┐
+      │Presence│         │Cursors │        │  CRDT  │
+      │  "3    │         │ Multi  │        │Conflict│
+      │online" │         │ select │        │  free  │
+      └────────┘         └────────┘        └────────┘
+          │                   │                 │
+       trivial            moderate           complex
+
+      Where's your head at?
+```
+
+**User brings a specific problem:**
+```
+User: The auth system is a mess
+
+You: [reads codebase]
+
+     ┌─────────────────────────────────────────────┐
+     │              CURRENT AUTH FLOW              │
+     └─────────────────────────────────────────────┘
+                        │
+          ┌─────────────┼─────────────┐
+          ▼             ▼             ▼
+     ┌─────────┐  ┌─────────┐  ┌─────────┐
+     │ Google  │  │  GitHub │  │  Email  │
+     │  OAuth  │  │  OAuth  │  │  Magic  │
+     └────┬────┘  └────┬────┘  └────┬────┘
+          │             │             │
+          └─────────────┼─────────────┘
+                        ▼
+                  ┌───────────┐
+                  │  Session  │
+                  └─────┬─────┘
+                        │
+                        ▼
+                  ┌───────────┐
+                  │   Perms   │
+                  └───────────┘
+
+     I see three tangles. Which one's burning?
+```
+
+**User is stuck mid-implementation:**
+```
+User: /opsx:explore add-auth-system
+      The OAuth integration is more complex than expected
+
+You: [reads change artifacts]
+
+     You're on task 4: "Implement OAuth flow"
+
+     Let me trace what's involved...
+
+     [draws diagram, explores options, suggests paths]
+
+     Want to update the design to reflect this?
+     Or add a spike task to investigate?
+```
+
+**User wants to compare options:**
+```
+User: Should we use Postgres or SQLite?
+
+You: Generic answer is boring. What's the context?
+
+User: A CLI tool that tracks local dev environments
+
+You: That changes everything.
+
+     ┌─────────────────────────────────────────────────┐
+     │         CLI TOOL DATA STORAGE                  │
+     └─────────────────────────────────────────────────┘
+
+     Key constraints:
+     • No daemon running
+     • Must work offline
+     • Single user
+
+                  SQLite          Postgres
+     Deployment   embedded ✓      needs server ✗
+     Offline      yes ✓           no ✗
+     Single file  yes ✓           no ✗
+
+     SQLite. Not even close.
+
+     Unless... is there a sync component?
+```
+
+---
+
+## Ending Discovery
+
+There's no required ending. Discovery might:
+
+- **Flow into a proposal**: "Ready to start? I can create a change proposal."
+- **Result in artifact updates**: "Updated design.md with these decisions"
+- **Just provide clarity**: User has what they need, moves on
+- **Continue later**: "We can pick this up anytime"
+
+When it feels like things are crystallizing, you might summarize:
+
+```
+## What We Figured Out
+
+**The problem**: [crystallized understanding]
+
+**The approach**: [if one emerged]
+
+**Open questions**: [if any remain]
+
+**Next steps** (if ready):
+- Create a change proposal
+- Keep exploring: just keep talking
+```
+
+But this summary is optional. Sometimes the thinking IS the value.
+
+---
+
+## Guardrails
+
+- **Don't implement** - Never write code or implement features. Creating OpenSpec artifacts is fine, writing application code is not.
+- **Don't fake understanding** - If something is unclear, dig deeper
+- **Don't rush** - Discovery is thinking time, not task time
+- **Don't force structure** - Let patterns emerge naturally
+- **Don't auto-capture** - Offer to save insights, don't just do it
+- **Do visualize** - A good diagram is worth many paragraphs
+- **Do explore the codebase** - Ground discussions in reality
+- **Do question assumptions** - Including the user's and your own

--- a/.codex/skills/openspec-propose/SKILL.md
+++ b/.codex/skills/openspec-propose/SKILL.md
@@ -1,0 +1,110 @@
+---
+name: openspec-propose
+description: Propose a new change with all artifacts generated in one step. Use when the user wants to quickly describe what they want to build and get a complete proposal with design, specs, and tasks ready for implementation.
+license: MIT
+compatibility: Requires openspec CLI.
+metadata:
+  author: openspec
+  version: "1.0"
+  generatedBy: "1.2.0"
+---
+
+Propose a new change - create the change and generate all artifacts in one step.
+
+I'll create a change with artifacts:
+- proposal.md (what & why)
+- design.md (how)
+- tasks.md (implementation steps)
+
+When ready to implement, run /opsx:apply
+
+---
+
+**Input**: The user's request should include a change name (kebab-case) OR a description of what they want to build.
+
+**Steps**
+
+1. **If no clear input provided, ask what they want to build**
+
+   Use the **AskUserQuestion tool** (open-ended, no preset options) to ask:
+   > "What change do you want to work on? Describe what you want to build or fix."
+
+   From their description, derive a kebab-case name (e.g., "add user authentication" → `add-user-auth`).
+
+   **IMPORTANT**: Do NOT proceed without understanding what the user wants to build.
+
+2. **Create the change directory**
+   ```bash
+   openspec new change "<name>"
+   ```
+   This creates a scaffolded change at `openspec/changes/<name>/` with `.openspec.yaml`.
+
+3. **Get the artifact build order**
+   ```bash
+   openspec status --change "<name>" --json
+   ```
+   Parse the JSON to get:
+   - `applyRequires`: array of artifact IDs needed before implementation (e.g., `["tasks"]`)
+   - `artifacts`: list of all artifacts with their status and dependencies
+
+4. **Create artifacts in sequence until apply-ready**
+
+   Use the **TodoWrite tool** to track progress through the artifacts.
+
+   Loop through artifacts in dependency order (artifacts with no pending dependencies first):
+
+   a. **For each artifact that is `ready` (dependencies satisfied)**:
+      - Get instructions:
+        ```bash
+        openspec instructions <artifact-id> --change "<name>" --json
+        ```
+      - The instructions JSON includes:
+        - `context`: Project background (constraints for you - do NOT include in output)
+        - `rules`: Artifact-specific rules (constraints for you - do NOT include in output)
+        - `template`: The structure to use for your output file
+        - `instruction`: Schema-specific guidance for this artifact type
+        - `outputPath`: Where to write the artifact
+        - `dependencies`: Completed artifacts to read for context
+      - Read any completed dependency files for context
+      - Create the artifact file using `template` as the structure
+      - Apply `context` and `rules` as constraints - but do NOT copy them into the file
+      - Show brief progress: "Created <artifact-id>"
+
+   b. **Continue until all `applyRequires` artifacts are complete**
+      - After creating each artifact, re-run `openspec status --change "<name>" --json`
+      - Check if every artifact ID in `applyRequires` has `status: "done"` in the artifacts array
+      - Stop when all `applyRequires` artifacts are done
+
+   c. **If an artifact requires user input** (unclear context):
+      - Use **AskUserQuestion tool** to clarify
+      - Then continue with creation
+
+5. **Show final status**
+   ```bash
+   openspec status --change "<name>"
+   ```
+
+**Output**
+
+After completing all artifacts, summarize:
+- Change name and location
+- List of artifacts created with brief descriptions
+- What's ready: "All artifacts created! Ready for implementation."
+- Prompt: "Run `/opsx:apply` or ask me to implement to start working on the tasks."
+
+**Artifact Creation Guidelines**
+
+- Follow the `instruction` field from `openspec instructions` for each artifact type
+- The schema defines what each artifact should contain - follow it
+- Read dependency artifacts for context before creating new ones
+- Use `template` as the structure for your output file - fill in its sections
+- **IMPORTANT**: `context` and `rules` are constraints for YOU, not content for the file
+  - Do NOT copy `<context>`, `<rules>`, `<project_context>` blocks into the artifact
+  - These guide what you write, but should never appear in the output
+
+**Guardrails**
+- Create ALL artifacts needed for implementation (as defined by schema's `apply.requires`)
+- Always read dependency artifacts before creating a new one
+- If context is critically unclear, ask the user - but prefer making reasonable decisions to keep momentum
+- If a change with that name already exists, ask if user wants to continue it or create a new one
+- Verify each artifact file exists after writing before proceeding to next

--- a/.gdc/nodes/Algorithm.yaml
+++ b/.gdc/nodes/Algorithm.yaml
@@ -24,4 +24,4 @@ interface:
           type: string
           access: get; set
 metadata:
-    status: ""
+    status: draft

--- a/.gdc/nodes/Constructor.yaml
+++ b/.gdc/nodes/Constructor.yaml
@@ -28,5 +28,9 @@ interface:
           type: '[]string'
           access: get; set
           description: 'C#: [Inject], [SerializeField], etc.'
+dependencies:
+    - target: Parameter
+      type: class
+      injection: field
 metadata:
-    status: ""
+    status: draft

--- a/.gdc/nodes/Dependency.yaml
+++ b/.gdc/nodes/Dependency.yaml
@@ -32,4 +32,4 @@ interface:
           type: string
           access: get; set
 metadata:
-    status: ""
+    status: draft

--- a/.gdc/nodes/Event.yaml
+++ b/.gdc/nodes/Event.yaml
@@ -24,4 +24,4 @@ interface:
           type: string
           access: get; set
 metadata:
-    status: ""
+    status: draft

--- a/.gdc/nodes/Interface.yaml
+++ b/.gdc/nodes/Interface.yaml
@@ -23,5 +23,18 @@ interface:
         - name: Events
           type: '[]Event'
           access: get; set
+dependencies:
+    - target: Constructor
+      type: class
+      injection: field
+    - target: Method
+      type: class
+      injection: field
+    - target: Property
+      type: class
+      injection: field
+    - target: Event
+      type: class
+      injection: field
 metadata:
-    status: ""
+    status: draft

--- a/.gdc/nodes/LanguageSpec.yaml
+++ b/.gdc/nodes/LanguageSpec.yaml
@@ -28,4 +28,4 @@ interface:
           access: get; set
           description: 'C#: class-level attributes like [Serializable]'
 metadata:
-    status: ""
+    status: draft

--- a/.gdc/nodes/Load.yaml
+++ b/.gdc/nodes/Load.yaml
@@ -1,0 +1,30 @@
+schema_version: "1.0"
+node:
+    id: Load
+    type: function
+    namespace: node
+    file_path: E:\works\gdc\internal\node\spec.go
+language_spec:
+    language: go
+    package: node
+responsibility:
+    summary: ""
+interface:
+    methods:
+        - name: Load
+          signature: Load(path string) (*Spec, error)
+          description: Load reads a node specification from a YAML file
+          parameters:
+            - name: path
+              type: string
+          returns:
+            type: (*Spec, error)
+          exported: true
+dependencies:
+    - target: Spec
+      type: class
+      injection: method
+metadata:
+    status: ""
+    origin: code_extracted
+    extracted_at: "2026-04-02"

--- a/.gdc/nodes/Logic.yaml
+++ b/.gdc/nodes/Logic.yaml
@@ -23,5 +23,12 @@ interface:
         - name: Pseudocode
           type: string
           access: get; set
+dependencies:
+    - target: StateMachine
+      type: class
+      injection: field
+    - target: Algorithm
+      type: class
+      injection: field
 metadata:
-    status: ""
+    status: draft

--- a/.gdc/nodes/Metadata.yaml
+++ b/.gdc/nodes/Metadata.yaml
@@ -15,6 +15,12 @@ interface:
           type: string
           access: get; set
           description: draft, specified, implemented, tested, deprecated
+        - name: Origin
+          type: string
+          access: get; set
+        - name: ExtractedAt
+          type: string
+          access: get; set
         - name: Created
           type: string
           access: get; set
@@ -45,4 +51,4 @@ interface:
           access: get; set
           description: Optional layer override
 metadata:
-    status: ""
+    status: draft

--- a/.gdc/nodes/Method.yaml
+++ b/.gdc/nodes/Method.yaml
@@ -57,5 +57,15 @@ interface:
           type: '[]string'
           access: get; set
           description: 'C#: [SerializeField], [Inject], etc.'
+dependencies:
+    - target: Parameter
+      type: class
+      injection: field
+    - target: Returns
+      type: class
+      injection: field
+    - target: Throws
+      type: class
+      injection: field
 metadata:
-    status: ""
+    status: draft

--- a/.gdc/nodes/Parameter.yaml
+++ b/.gdc/nodes/Parameter.yaml
@@ -30,4 +30,4 @@ interface:
           type: string
           access: get; set
 metadata:
-    status: ""
+    status: draft

--- a/.gdc/nodes/Property.yaml
+++ b/.gdc/nodes/Property.yaml
@@ -44,4 +44,4 @@ interface:
           access: get; set
           description: 'C#: [SerializeField], [JsonIgnore], etc.'
 metadata:
-    status: ""
+    status: draft

--- a/.gdc/nodes/Responsibility.yaml
+++ b/.gdc/nodes/Responsibility.yaml
@@ -24,4 +24,4 @@ interface:
           type: string
           access: get; set
 metadata:
-    status: ""
+    status: draft

--- a/.gdc/nodes/Returns.yaml
+++ b/.gdc/nodes/Returns.yaml
@@ -21,4 +21,4 @@ interface:
           type: bool
           access: get; set
 metadata:
-    status: ""
+    status: draft

--- a/.gdc/nodes/Save.yaml
+++ b/.gdc/nodes/Save.yaml
@@ -1,0 +1,32 @@
+schema_version: "1.0"
+node:
+    id: Save
+    type: function
+    namespace: node
+    file_path: E:\works\gdc\internal\node\spec.go
+language_spec:
+    language: go
+    package: node
+responsibility:
+    summary: ""
+interface:
+    methods:
+        - name: Save
+          signature: Save(path string, spec *Spec) error
+          description: Save writes a node specification to a YAML file
+          parameters:
+            - name: path
+              type: string
+            - name: spec
+              type: '*Spec'
+          returns:
+            type: error
+          exported: true
+dependencies:
+    - target: Spec
+      type: class
+      injection: method
+metadata:
+    status: ""
+    origin: code_extracted
+    extracted_at: "2026-04-02"

--- a/.gdc/nodes/Spec.yaml
+++ b/.gdc/nodes/Spec.yaml
@@ -32,6 +32,11 @@ interface:
           returns:
             type: bool
           exported: true
+        - name: QualifiedID
+          signature: QualifiedID() string
+          returns:
+            type: string
+          exported: true
     properties:
         - name: SchemaVersion
           type: string
@@ -61,5 +66,30 @@ interface:
         - name: Metadata
           type: Metadata
           access: get; set
+        - name: SourcePath
+          type: string
+          access: get; set
+dependencies:
+    - target: NodeInfo
+      type: class
+      injection: field
+    - target: LanguageSpec
+      type: class
+      injection: field
+    - target: Responsibility
+      type: class
+      injection: field
+    - target: Interface
+      type: class
+      injection: field
+    - target: Dependency
+      type: class
+      injection: field
+    - target: Logic
+      type: class
+      injection: field
+    - target: Metadata
+      type: class
+      injection: field
 metadata:
     status: draft

--- a/.gdc/nodes/State.yaml
+++ b/.gdc/nodes/State.yaml
@@ -26,5 +26,9 @@ interface:
         - name: Transitions
           type: '[]Transition'
           access: get; set
+dependencies:
+    - target: Transition
+      type: class
+      injection: field
 metadata:
-    status: ""
+    status: draft

--- a/.gdc/nodes/StateMachine.yaml
+++ b/.gdc/nodes/StateMachine.yaml
@@ -17,5 +17,9 @@ interface:
         - name: States
           type: '[]State'
           access: get; set
+dependencies:
+    - target: State
+      type: class
+      injection: field
 metadata:
-    status: ""
+    status: draft

--- a/.gdc/nodes/Throws.yaml
+++ b/.gdc/nodes/Throws.yaml
@@ -18,4 +18,4 @@ interface:
           type: string
           access: get; set
 metadata:
-    status: ""
+    status: draft

--- a/.gdc/nodes/Transition.yaml
+++ b/.gdc/nodes/Transition.yaml
@@ -24,4 +24,4 @@ interface:
           type: string
           access: get; set
 metadata:
-    status: ""
+    status: draft

--- a/.gdc/nodes/candidateSourceNodeIDs.yaml
+++ b/.gdc/nodes/candidateSourceNodeIDs.yaml
@@ -1,0 +1,15 @@
+schema_version: "1.0"
+node:
+    id: candidateSourceNodeIDs
+    type: function
+    namespace: cli
+    file_path: E:\works\gdc\internal\cli\check.go
+language_spec:
+    language: go
+    package: cli
+responsibility:
+    summary: ""
+metadata:
+    status: ""
+    origin: code_extracted
+    extracted_at: "2026-04-02"

--- a/.gdc/nodes/checkCycles.yaml
+++ b/.gdc/nodes/checkCycles.yaml
@@ -1,0 +1,15 @@
+schema_version: "1.0"
+node:
+    id: checkCycles
+    type: function
+    namespace: cli
+    file_path: E:\works\gdc\internal\cli\check.go
+language_spec:
+    language: go
+    package: cli
+responsibility:
+    summary: ""
+metadata:
+    status: ""
+    origin: code_extracted
+    extracted_at: "2026-04-02"

--- a/.gdc/nodes/checkHashMismatch.yaml
+++ b/.gdc/nodes/checkHashMismatch.yaml
@@ -1,0 +1,15 @@
+schema_version: "1.0"
+node:
+    id: checkHashMismatch
+    type: function
+    namespace: cli
+    file_path: E:\works\gdc\internal\cli\check.go
+language_spec:
+    language: go
+    package: cli
+responsibility:
+    summary: ""
+metadata:
+    status: ""
+    origin: code_extracted
+    extracted_at: "2026-04-02"

--- a/.gdc/nodes/checkImplementationConsistency.yaml
+++ b/.gdc/nodes/checkImplementationConsistency.yaml
@@ -1,0 +1,15 @@
+schema_version: "1.0"
+node:
+    id: checkImplementationConsistency
+    type: function
+    namespace: cli
+    file_path: E:\works\gdc\internal\cli\check.go
+language_spec:
+    language: go
+    package: cli
+responsibility:
+    summary: ""
+metadata:
+    status: ""
+    origin: code_extracted
+    extracted_at: "2026-04-02"

--- a/.gdc/nodes/checkLayerViolations.yaml
+++ b/.gdc/nodes/checkLayerViolations.yaml
@@ -1,0 +1,15 @@
+schema_version: "1.0"
+node:
+    id: checkLayerViolations
+    type: function
+    namespace: cli
+    file_path: E:\works\gdc\internal\cli\check.go
+language_spec:
+    language: go
+    package: cli
+responsibility:
+    summary: ""
+metadata:
+    status: ""
+    origin: code_extracted
+    extracted_at: "2026-04-02"

--- a/.gdc/nodes/checkMissingRefs.yaml
+++ b/.gdc/nodes/checkMissingRefs.yaml
@@ -1,0 +1,15 @@
+schema_version: "1.0"
+node:
+    id: checkMissingRefs
+    type: function
+    namespace: cli
+    file_path: E:\works\gdc\internal\cli\check.go
+language_spec:
+    language: go
+    package: cli
+responsibility:
+    summary: ""
+metadata:
+    status: ""
+    origin: code_extracted
+    extracted_at: "2026-04-02"

--- a/.gdc/nodes/checkOrphans.yaml
+++ b/.gdc/nodes/checkOrphans.yaml
@@ -1,0 +1,15 @@
+schema_version: "1.0"
+node:
+    id: checkOrphans
+    type: function
+    namespace: cli
+    file_path: E:\works\gdc\internal\cli\check.go
+language_spec:
+    language: go
+    package: cli
+responsibility:
+    summary: ""
+metadata:
+    status: ""
+    origin: code_extracted
+    extracted_at: "2026-04-02"

--- a/.gdc/nodes/checkSRPViolations.yaml
+++ b/.gdc/nodes/checkSRPViolations.yaml
@@ -1,0 +1,15 @@
+schema_version: "1.0"
+node:
+    id: checkSRPViolations
+    type: function
+    namespace: cli
+    file_path: E:\works\gdc\internal\cli\check.go
+language_spec:
+    language: go
+    package: cli
+responsibility:
+    summary: ""
+metadata:
+    status: ""
+    origin: code_extracted
+    extracted_at: "2026-04-02"

--- a/.gdc/nodes/compareSpecToImplementation.yaml
+++ b/.gdc/nodes/compareSpecToImplementation.yaml
@@ -1,0 +1,15 @@
+schema_version: "1.0"
+node:
+    id: compareSpecToImplementation
+    type: function
+    namespace: cli
+    file_path: E:\works\gdc\internal\cli\check.go
+language_spec:
+    language: go
+    package: cli
+responsibility:
+    summary: ""
+metadata:
+    status: ""
+    origin: code_extracted
+    extracted_at: "2026-04-02"

--- a/.gdc/nodes/countBySeverity.yaml
+++ b/.gdc/nodes/countBySeverity.yaml
@@ -1,0 +1,15 @@
+schema_version: "1.0"
+node:
+    id: countBySeverity
+    type: function
+    namespace: cli
+    file_path: E:\works\gdc\internal\cli\check.go
+language_spec:
+    language: go
+    package: cli
+responsibility:
+    summary: ""
+metadata:
+    status: ""
+    origin: code_extracted
+    extracted_at: "2026-04-02"

--- a/.gdc/nodes/detectCycle.yaml
+++ b/.gdc/nodes/detectCycle.yaml
@@ -1,0 +1,15 @@
+schema_version: "1.0"
+node:
+    id: detectCycle
+    type: function
+    namespace: cli
+    file_path: E:\works\gdc\internal\cli\check.go
+language_spec:
+    language: go
+    package: cli
+responsibility:
+    summary: ""
+metadata:
+    status: ""
+    origin: code_extracted
+    extracted_at: "2026-04-02"

--- a/.gdc/nodes/displayIssues.yaml
+++ b/.gdc/nodes/displayIssues.yaml
@@ -1,0 +1,15 @@
+schema_version: "1.0"
+node:
+    id: displayIssues
+    type: function
+    namespace: cli
+    file_path: E:\works\gdc\internal\cli\check.go
+language_spec:
+    language: go
+    package: cli
+responsibility:
+    summary: ""
+metadata:
+    status: ""
+    origin: code_extracted
+    extracted_at: "2026-04-02"

--- a/.gdc/nodes/evaluateCheckExitPolicy.yaml
+++ b/.gdc/nodes/evaluateCheckExitPolicy.yaml
@@ -1,0 +1,15 @@
+schema_version: "1.0"
+node:
+    id: evaluateCheckExitPolicy
+    type: function
+    namespace: cli
+    file_path: E:\works\gdc\internal\cli\check.go
+language_spec:
+    language: go
+    package: cli
+responsibility:
+    summary: ""
+metadata:
+    status: ""
+    origin: code_extracted
+    extracted_at: "2026-04-02"

--- a/.gdc/nodes/filterIssues.yaml
+++ b/.gdc/nodes/filterIssues.yaml
@@ -1,0 +1,15 @@
+schema_version: "1.0"
+node:
+    id: filterIssues
+    type: function
+    namespace: cli
+    file_path: E:\works\gdc\internal\cli\check.go
+language_spec:
+    language: go
+    package: cli
+responsibility:
+    summary: ""
+metadata:
+    status: ""
+    origin: code_extracted
+    extracted_at: "2026-04-02"

--- a/.gdc/nodes/findExtractedNodeInFile.yaml
+++ b/.gdc/nodes/findExtractedNodeInFile.yaml
@@ -1,0 +1,15 @@
+schema_version: "1.0"
+node:
+    id: findExtractedNodeInFile
+    type: function
+    namespace: cli
+    file_path: E:\works\gdc\internal\cli\check.go
+language_spec:
+    language: go
+    package: cli
+responsibility:
+    summary: ""
+metadata:
+    status: ""
+    origin: code_extracted
+    extracted_at: "2026-04-02"

--- a/.gdc/nodes/formatCISummary.yaml
+++ b/.gdc/nodes/formatCISummary.yaml
@@ -1,0 +1,15 @@
+schema_version: "1.0"
+node:
+    id: formatCISummary
+    type: function
+    namespace: cli
+    file_path: E:\works\gdc\internal\cli\check.go
+language_spec:
+    language: go
+    package: cli
+responsibility:
+    summary: ""
+metadata:
+    status: ""
+    origin: code_extracted
+    extracted_at: "2026-04-02"

--- a/.gdc/nodes/hasAllowedOrphanTag.yaml
+++ b/.gdc/nodes/hasAllowedOrphanTag.yaml
@@ -1,0 +1,15 @@
+schema_version: "1.0"
+node:
+    id: hasAllowedOrphanTag
+    type: function
+    namespace: cli
+    file_path: E:\works\gdc\internal\cli\check.go
+language_spec:
+    language: go
+    package: cli
+responsibility:
+    summary: ""
+metadata:
+    status: ""
+    origin: code_extracted
+    extracted_at: "2026-04-02"

--- a/.gdc/nodes/implVerificationResult.yaml
+++ b/.gdc/nodes/implVerificationResult.yaml
@@ -1,0 +1,15 @@
+schema_version: "1.0"
+node:
+    id: implVerificationResult
+    type: class
+    namespace: cli
+    file_path: E:\works\gdc\internal\cli\check.go
+language_spec:
+    language: go
+    package: cli
+responsibility:
+    summary: ""
+metadata:
+    status: ""
+    origin: code_extracted
+    extracted_at: "2026-04-02"

--- a/.gdc/nodes/inferredAllowedOrphan.yaml
+++ b/.gdc/nodes/inferredAllowedOrphan.yaml
@@ -1,0 +1,15 @@
+schema_version: "1.0"
+node:
+    id: inferredAllowedOrphan
+    type: function
+    namespace: cli
+    file_path: E:\works\gdc\internal\cli\check.go
+language_spec:
+    language: go
+    package: cli
+responsibility:
+    summary: ""
+metadata:
+    status: ""
+    origin: code_extracted
+    extracted_at: "2026-04-02"

--- a/.gdc/nodes/init.yaml
+++ b/.gdc/nodes/init.yaml
@@ -1,0 +1,15 @@
+schema_version: "1.0"
+node:
+    id: init
+    type: function
+    namespace: cli
+    file_path: E:\works\gdc\internal\cli\check.go
+language_spec:
+    language: go
+    package: cli
+responsibility:
+    summary: ""
+metadata:
+    status: ""
+    origin: code_extracted
+    extracted_at: "2026-04-02"

--- a/.gdc/nodes/isDisabled.yaml
+++ b/.gdc/nodes/isDisabled.yaml
@@ -1,0 +1,15 @@
+schema_version: "1.0"
+node:
+    id: isDisabled
+    type: function
+    namespace: cli
+    file_path: E:\works\gdc\internal\cli\check.go
+language_spec:
+    language: go
+    package: cli
+responsibility:
+    summary: ""
+metadata:
+    status: ""
+    origin: code_extracted
+    extracted_at: "2026-04-02"

--- a/.gdc/nodes/isWarnOnly.yaml
+++ b/.gdc/nodes/isWarnOnly.yaml
@@ -1,0 +1,15 @@
+schema_version: "1.0"
+node:
+    id: isWarnOnly
+    type: function
+    namespace: cli
+    file_path: E:\works\gdc\internal\cli\check.go
+language_spec:
+    language: go
+    package: cli
+responsibility:
+    summary: ""
+metadata:
+    status: ""
+    origin: code_extracted
+    extracted_at: "2026-04-02"

--- a/.gdc/nodes/matchExtractedNodeByID.yaml
+++ b/.gdc/nodes/matchExtractedNodeByID.yaml
@@ -1,0 +1,15 @@
+schema_version: "1.0"
+node:
+    id: matchExtractedNodeByID
+    type: function
+    namespace: cli
+    file_path: E:\works\gdc\internal\cli\check.go
+language_spec:
+    language: go
+    package: cli
+responsibility:
+    summary: ""
+metadata:
+    status: ""
+    origin: code_extracted
+    extracted_at: "2026-04-02"

--- a/.gdc/nodes/matchesPattern.yaml
+++ b/.gdc/nodes/matchesPattern.yaml
@@ -1,0 +1,15 @@
+schema_version: "1.0"
+node:
+    id: matchesPattern
+    type: function
+    namespace: cli
+    file_path: E:\works\gdc\internal\cli\check.go
+language_spec:
+    language: go
+    package: cli
+responsibility:
+    summary: ""
+metadata:
+    status: ""
+    origin: code_extracted
+    extracted_at: "2026-04-02"

--- a/.gdc/nodes/nodeInfo.yaml
+++ b/.gdc/nodes/nodeInfo.yaml
@@ -10,6 +10,12 @@ language_spec:
 responsibility:
     summary: ""
 interface:
+    methods:
+        - name: QualifiedID
+          signature: QualifiedID() string
+          returns:
+            type: string
+          exported: true
     properties:
         - name: ID
           type: string
@@ -17,7 +23,7 @@ interface:
         - name: Type
           type: string
           access: get; set
-          description: class, interface, module, service, enum
+          description: class, interface, module, service, enum, function
         - name: Layer
           type: string
           access: get; set
@@ -29,4 +35,4 @@ interface:
           type: string
           access: get; set
 metadata:
-    status: ""
+    status: draft

--- a/.gdc/nodes/normalizeSignature.yaml
+++ b/.gdc/nodes/normalizeSignature.yaml
@@ -1,0 +1,15 @@
+schema_version: "1.0"
+node:
+    id: normalizeSignature
+    type: function
+    namespace: cli
+    file_path: E:\works\gdc\internal\cli\check.go
+language_spec:
+    language: go
+    package: cli
+responsibility:
+    summary: ""
+metadata:
+    status: ""
+    origin: code_extracted
+    extracted_at: "2026-04-02"

--- a/.gdc/nodes/printStatsTable.yaml
+++ b/.gdc/nodes/printStatsTable.yaml
@@ -1,0 +1,15 @@
+schema_version: "1.0"
+node:
+    id: printStatsTable
+    type: function
+    namespace: cli
+    file_path: E:\works\gdc\internal\cli\check.go
+language_spec:
+    language: go
+    package: cli
+responsibility:
+    summary: ""
+metadata:
+    status: ""
+    origin: code_extracted
+    extracted_at: "2026-04-02"

--- a/.gdc/nodes/resolveLayerViolationSeverity.yaml
+++ b/.gdc/nodes/resolveLayerViolationSeverity.yaml
@@ -1,0 +1,15 @@
+schema_version: "1.0"
+node:
+    id: resolveLayerViolationSeverity
+    type: function
+    namespace: cli
+    file_path: E:\works\gdc\internal\cli\check.go
+language_spec:
+    language: go
+    package: cli
+responsibility:
+    summary: ""
+metadata:
+    status: ""
+    origin: code_extracted
+    extracted_at: "2026-04-02"

--- a/.gdc/nodes/runCheck.yaml
+++ b/.gdc/nodes/runCheck.yaml
@@ -1,0 +1,15 @@
+schema_version: "1.0"
+node:
+    id: runCheck
+    type: function
+    namespace: cli
+    file_path: E:\works\gdc\internal\cli\check.go
+language_spec:
+    language: go
+    package: cli
+responsibility:
+    summary: ""
+metadata:
+    status: ""
+    origin: code_extracted
+    extracted_at: "2026-04-02"

--- a/.gdc/nodes/shouldIgnoreOrphan.yaml
+++ b/.gdc/nodes/shouldIgnoreOrphan.yaml
@@ -1,0 +1,15 @@
+schema_version: "1.0"
+node:
+    id: shouldIgnoreOrphan
+    type: function
+    namespace: cli
+    file_path: E:\works\gdc\internal\cli\check.go
+language_spec:
+    language: go
+    package: cli
+responsibility:
+    summary: ""
+metadata:
+    status: ""
+    origin: code_extracted
+    extracted_at: "2026-04-02"

--- a/.gdc/nodes/signaturesCompatible.yaml
+++ b/.gdc/nodes/signaturesCompatible.yaml
@@ -1,0 +1,15 @@
+schema_version: "1.0"
+node:
+    id: signaturesCompatible
+    type: function
+    namespace: cli
+    file_path: E:\works\gdc\internal\cli\check.go
+language_spec:
+    language: go
+    package: cli
+responsibility:
+    summary: ""
+metadata:
+    status: ""
+    origin: code_extracted
+    extracted_at: "2026-04-02"

--- a/.gdc/nodes/symbolExistsInSource.yaml
+++ b/.gdc/nodes/symbolExistsInSource.yaml
@@ -1,0 +1,15 @@
+schema_version: "1.0"
+node:
+    id: symbolExistsInSource
+    type: function
+    namespace: cli
+    file_path: E:\works\gdc\internal\cli\check.go
+language_spec:
+    language: go
+    package: cli
+responsibility:
+    summary: ""
+metadata:
+    status: ""
+    origin: code_extracted
+    extracted_at: "2026-04-02"

--- a/.gdc/nodes/typesCompatible.yaml
+++ b/.gdc/nodes/typesCompatible.yaml
@@ -1,0 +1,15 @@
+schema_version: "1.0"
+node:
+    id: typesCompatible
+    type: function
+    namespace: cli
+    file_path: E:\works\gdc\internal\cli\check.go
+language_spec:
+    language: go
+    package: cli
+responsibility:
+    summary: ""
+metadata:
+    status: ""
+    origin: code_extracted
+    extracted_at: "2026-04-02"

--- a/.gdc/nodes/verifyNodeImplementation.yaml
+++ b/.gdc/nodes/verifyNodeImplementation.yaml
@@ -1,0 +1,15 @@
+schema_version: "1.0"
+node:
+    id: verifyNodeImplementation
+    type: function
+    namespace: cli
+    file_path: E:\works\gdc\internal\cli\check.go
+language_spec:
+    language: go
+    package: cli
+responsibility:
+    summary: ""
+metadata:
+    status: ""
+    origin: code_extracted
+    extracted_at: "2026-04-02"

--- a/internal/cli/check.go
+++ b/internal/cli/check.go
@@ -650,27 +650,47 @@ func verifyNodeImplementation(spec *node.Spec, resolvedPath, lang string, p pars
 }
 
 func findExtractedNodeInFile(p parser.Parser, path, nodeID string) (*parser.ExtractedNode, error) {
+	candidateIDs := candidateSourceNodeIDs(nodeID)
 	if multi, ok := p.(parser.MultiNodeParser); ok {
 		extractedNodes, err := multi.ParseFileNodes(path)
 		if err != nil {
 			return nil, err
 		}
-		for _, extracted := range extractedNodes {
-			if extracted != nil && extracted.ID == nodeID {
-				return extracted, nil
-			}
-		}
-		return nil, nil
+		return matchExtractedNodeByID(extractedNodes, candidateIDs), nil
 	}
 
 	extracted, err := p.ParseFile(path)
 	if err != nil {
 		return nil, err
 	}
-	if extracted != nil && extracted.ID == nodeID {
-		return extracted, nil
+	if match := matchExtractedNodeByID([]*parser.ExtractedNode{extracted}, candidateIDs); match != nil {
+		return match, nil
 	}
 	return nil, nil
+}
+
+func candidateSourceNodeIDs(nodeID string) []string {
+	nodeID = strings.TrimSpace(nodeID)
+	if nodeID == "" {
+		return nil
+	}
+
+	candidates := []string{nodeID}
+	if idx := strings.LastIndex(nodeID, "."); idx >= 0 && idx < len(nodeID)-1 {
+		candidates = append(candidates, nodeID[idx+1:])
+	}
+	return dedupeStrings(candidates)
+}
+
+func matchExtractedNodeByID(extractedNodes []*parser.ExtractedNode, candidateIDs []string) *parser.ExtractedNode {
+	for _, candidateID := range candidateIDs {
+		for _, extracted := range extractedNodes {
+			if extracted != nil && extracted.ID == candidateID {
+				return extracted
+			}
+		}
+	}
+	return nil
 }
 
 func symbolExistsInSource(lang, content, nodeID, nodeType string) bool {

--- a/internal/cli/diff_test.go
+++ b/internal/cli/diff_test.go
@@ -100,3 +100,63 @@ func TestBuildDriftReportEmptyWhenSpecMatchesCode(t *testing.T) {
 		t.Fatalf("expected no drift, got %+v", report)
 	}
 }
+
+func TestFindExtractedNodeInFileMatchesTerminalSymbolForDottedIDs(t *testing.T) {
+	parser := fakeMultiNodeParser{
+		nodes: []*parser.ExtractedNode{
+			{ID: "Runtime"},
+			{ID: "Other"},
+		},
+	}
+
+	match, err := findExtractedNodeInFile(parser, "ignored.go", "tools.Runtime")
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if match == nil || match.ID != "Runtime" {
+		t.Fatalf("expected Runtime match, got %+v", match)
+	}
+}
+
+func TestFindExtractedNodeInFilePrefersExactIDBeforeTerminalFallback(t *testing.T) {
+	parser := fakeMultiNodeParser{
+		nodes: []*parser.ExtractedNode{
+			{ID: "Runtime"},
+			{ID: "tools.Runtime"},
+		},
+	}
+
+	match, err := findExtractedNodeInFile(parser, "ignored.go", "tools.Runtime")
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if match == nil || match.ID != "tools.Runtime" {
+		t.Fatalf("expected exact tools.Runtime match, got %+v", match)
+	}
+}
+
+type fakeMultiNodeParser struct {
+	nodes []*parser.ExtractedNode
+	err   error
+}
+
+func (f fakeMultiNodeParser) ParseFile(path string) (*parser.ExtractedNode, error) {
+	if f.err != nil {
+		return nil, f.err
+	}
+	if len(f.nodes) == 0 {
+		return nil, nil
+	}
+	return f.nodes[0], nil
+}
+
+func (f fakeMultiNodeParser) ParseFileNodes(path string) ([]*parser.ExtractedNode, error) {
+	if f.err != nil {
+		return nil, f.err
+	}
+	return f.nodes, nil
+}
+
+func (f fakeMultiNodeParser) Language() string {
+	return "go"
+}

--- a/internal/node/spec.go
+++ b/internal/node/spec.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"gopkg.in/yaml.v3"
 )
@@ -302,8 +303,13 @@ func (s *Spec) QualifiedID() string {
 }
 
 func (n NodeInfo) QualifiedID() string {
-	if n.Namespace == "" {
-		return n.ID
+	id := strings.TrimSpace(n.ID)
+	namespace := strings.TrimSpace(n.Namespace)
+	if namespace == "" {
+		return id
 	}
-	return n.Namespace + "." + n.ID
+	if id == namespace || strings.HasPrefix(id, namespace+".") {
+		return id
+	}
+	return namespace + "." + id
 }

--- a/internal/node/spec_test.go
+++ b/internal/node/spec_test.go
@@ -1,0 +1,25 @@
+package node
+
+import "testing"
+
+func TestNodeInfoQualifiedIDPrefixesNamespaceForBareIDs(t *testing.T) {
+	info := NodeInfo{
+		ID:        "Runtime",
+		Namespace: "tools",
+	}
+
+	if got := info.QualifiedID(); got != "tools.Runtime" {
+		t.Fatalf("expected tools.Runtime, got %q", got)
+	}
+}
+
+func TestNodeInfoQualifiedIDDoesNotDoublePrefixDottedIDs(t *testing.T) {
+	info := NodeInfo{
+		ID:        "tools.Runtime",
+		Namespace: "tools",
+	}
+
+	if got := info.QualifiedID(); got != "tools.Runtime" {
+		t.Fatalf("expected tools.Runtime, got %q", got)
+	}
+}

--- a/openspec/changes/archive/2026-04-02-fix-dotted-node-id-resolution/.openspec.yaml
+++ b/openspec/changes/archive/2026-04-02-fix-dotted-node-id-resolution/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-02

--- a/openspec/changes/archive/2026-04-02-fix-dotted-node-id-resolution/design.md
+++ b/openspec/changes/archive/2026-04-02-fix-dotted-node-id-resolution/design.md
@@ -1,0 +1,30 @@
+## Context
+
+`gdc sync --direction code` resolves duplicate extracted IDs by writing a dotted identifier into `node.id`. The current `QualifiedID()` implementation always prepends `namespace`, which double-prefixes synced nodes like `tools.Runtime` into `tools.tools.Runtime`. Separately, `diff` and implementation verification search source using the literal stored `node.id`, which fails because parsed source symbols remain bare (`Runtime`, `CapacityStore`, and similar).
+
+## Goals / Non-Goals
+
+**Goals:**
+- Preserve dotted synced IDs as valid canonical identifiers without double-prefixing the namespace.
+- Allow `diff` and implementation verification to locate the underlying source symbol for dotted synced IDs.
+- Lock the behavior with regression tests close to the affected helpers.
+
+**Non-Goals:**
+- Redesign the sync ID scheme or migrate existing specs to a different storage model.
+- Normalize every historical GDC node file in the repository.
+- Change how non-dotted node IDs are resolved.
+
+## Decisions
+
+- Treat `node.id` as already canonical when it exactly equals `namespace` or starts with `namespace.`.
+  Rationale: this is the smallest fix that makes `query/show` agree with code-synced specs without changing the sync format.
+- Resolve source lookup for dotted IDs by matching both the stored ID and its terminal symbol segment.
+  Rationale: synced IDs intentionally carry collision context, but parsers still return the real source symbol name. Matching the terminal segment fixes `diff/check` while keeping exact matches preferred.
+- Add targeted unit tests instead of a full CLI integration test.
+  Rationale: the bug sits in shared helpers (`QualifiedID` and extracted-node lookup), so focused tests give fast coverage with less setup noise.
+
+## Risks / Trade-offs
+
+- [Risk] A dotted ID that is also a real source symbol string could ambiguously match two candidates. → Mitigation: prefer exact full-ID matches before falling back to the terminal segment.
+- [Risk] Existing callers may rely on double-prefixed canonical IDs in snapshots or logs. → Mitigation: limit the change to cases where `node.id` already starts with the namespace.
+- [Risk] Future sync formats might encode more than one qualifier segment. → Mitigation: source lookup uses the terminal segment generically rather than assuming a single prefix.

--- a/openspec/changes/archive/2026-04-02-fix-dotted-node-id-resolution/proposal.md
+++ b/openspec/changes/archive/2026-04-02-fix-dotted-node-id-resolution/proposal.md
@@ -1,0 +1,22 @@
+## Why
+
+Code sync can emit node IDs that already include qualifying segments such as package or path context. Today, `query` and `show` derive canonical IDs differently from `diff`, so the same synced node can appear addressable in one command and unresolved in another.
+
+## What Changes
+
+- Make canonical node IDs stable when `node.id` already contains its namespace prefix.
+- Make implementation lookup in `diff` and `check` resolve dotted synced IDs back to the source symbol name found in code.
+- Add regression coverage for dotted synced IDs across canonical ID generation and source lookup.
+
+## Capabilities
+
+### New Capabilities
+- `node-id-resolution`: Ensure GDC commands interpret dotted synced node IDs consistently across query, show, diff, and implementation verification.
+
+### Modified Capabilities
+
+## Impact
+
+- Affected code: `internal/node`, `internal/cli/diff.go`, `internal/cli/check.go`, and related tests.
+- User-facing impact: fixes false "symbol not found" failures for code-synced dotted IDs.
+- No new dependencies or external API changes.

--- a/openspec/changes/archive/2026-04-02-fix-dotted-node-id-resolution/specs/node-id-resolution/spec.md
+++ b/openspec/changes/archive/2026-04-02-fix-dotted-node-id-resolution/specs/node-id-resolution/spec.md
@@ -1,0 +1,17 @@
+## ADDED Requirements
+
+### Requirement: Canonical IDs SHALL remain stable for dotted synced node IDs
+When a node spec already stores a `node.id` that includes the namespace prefix used to avoid collisions, GDC SHALL not prepend the namespace a second time when deriving the canonical ID exposed by query, show, graph, or sync-backed lookups.
+
+#### Scenario: Namespace-prefixed ID remains canonical
+- **WHEN** a node spec has `namespace: tools` and `node.id: tools.Runtime`
+- **THEN** the canonical ID is `tools.Runtime`
+- **THEN** GDC does not emit `tools.tools.Runtime`
+
+### Requirement: Implementation lookup SHALL resolve dotted synced IDs to source symbols
+When a synced node stores a dotted `node.id`, GDC SHALL still locate the implementation symbol in source files for diff and implementation verification commands.
+
+#### Scenario: Diff resolves terminal symbol from dotted ID
+- **WHEN** a node spec has `node.id: file.CapacityStore` and the parsed source symbol is `CapacityStore`
+- **THEN** diff and implementation verification match that extracted symbol
+- **THEN** GDC does not fail with a false "symbol not found" error solely because the stored ID is dotted

--- a/openspec/changes/archive/2026-04-02-fix-dotted-node-id-resolution/tasks.md
+++ b/openspec/changes/archive/2026-04-02-fix-dotted-node-id-resolution/tasks.md
@@ -1,0 +1,9 @@
+## 1. Resolution Semantics
+
+- [x] 1.1 Update canonical ID generation to avoid double-prefixing when `node.id` already starts with `namespace.`
+- [x] 1.2 Update extracted-node lookup to resolve dotted synced IDs against parsed source symbols
+
+## 2. Verification
+
+- [x] 2.1 Add regression tests for canonical dotted IDs and dotted source lookup
+- [x] 2.2 Run focused Go tests for the touched CLI and node packages

--- a/openspec/specs/node-id-resolution/spec.md
+++ b/openspec/specs/node-id-resolution/spec.md
@@ -1,0 +1,20 @@
+# node-id-resolution Specification
+
+## Purpose
+Define how GDC interprets canonical node IDs and source-symbol lookup when code sync emits dotted node identifiers to disambiguate collisions.
+## Requirements
+### Requirement: Canonical IDs SHALL remain stable for dotted synced node IDs
+When a node spec already stores a `node.id` that includes the namespace prefix used to avoid collisions, GDC SHALL not prepend the namespace a second time when deriving the canonical ID exposed by query, show, graph, or sync-backed lookups.
+
+#### Scenario: Namespace-prefixed ID remains canonical
+- **WHEN** a node spec has `namespace: tools` and `node.id: tools.Runtime`
+- **THEN** the canonical ID is `tools.Runtime`
+- **THEN** GDC does not emit `tools.tools.Runtime`
+
+### Requirement: Implementation lookup SHALL resolve dotted synced IDs to source symbols
+When a synced node stores a dotted `node.id`, GDC SHALL still locate the implementation symbol in source files for diff and implementation verification commands.
+
+#### Scenario: Diff resolves terminal symbol from dotted ID
+- **WHEN** a node spec has `node.id: file.CapacityStore` and the parsed source symbol is `CapacityStore`
+- **THEN** diff and implementation verification match that extracted symbol
+- **THEN** GDC does not fail with a false "symbol not found" error solely because the stored ID is dotted


### PR DESCRIPTION
## Summary
- fix dotted node id resolution for synced nodes
- keep canonical IDs stable when node.id already includes namespace context
- resolve dotted IDs to terminal source symbols during diff/check
- archive the related OpenSpec change and sync touched GDC nodes

## Validation
- go test ./internal/node -run TestNodeInfoQualifiedID -count=1
- go test ./internal/cli -run "TestFindExtractedNodeInFile|TestBuildDriftReport" -count=1
- openspec validate node-id-resolution


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  - Introduced OpenSpec workflow skills for applying changes, archiving completed work, exploring design ideas, and proposing new changes.
  - Enhanced node system architecture with expanded specifications and dependency declarations.

* **Bug Fixes**
  - Fixed dotted node identifier resolution to prevent namespace double-prefixing in canonical ID generation.

* **Documentation**
  - Added node-id-resolution specification and supporting design documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->